### PR TITLE
avoids race condition for getting http status

### DIFF
--- a/buildSrc/msintplugin/build.gradle
+++ b/buildSrc/msintplugin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 
-project.version = '1.1.7'
+project.version = '1.1.8'
 project.group = 'de.db.vz'
 
 apply plugin: 'com.gradle.plugin-publish'

--- a/buildSrc/msintplugin/src/main/groovy/de/db/vz/integrationtestplugin/service/healthcheck/HttpHealthCheck.groovy
+++ b/buildSrc/msintplugin/src/main/groovy/de/db/vz/integrationtestplugin/service/healthcheck/HttpHealthCheck.groovy
@@ -30,7 +30,7 @@ class HttpHealthCheck extends HealthCheck {
 
         def builder = new ProcessBuilder('docker', 'run', '--rm', "--net=$network",
                 IntegrationTestPlugin.integrationTestExtension.curlImage,
-                '-s', '-o', '/dev/null', '-w', '%{http_code}',
+                '-sw','\'%{http_code}\n\'', '-o', '/dev/null',
                 "http://${service}${healthEndpoint}")
         logger.debug("health check docker command: ${builder.command()}")
         Process process = builder.start()

--- a/buildSrc/msintplugin/src/main/groovy/de/db/vz/integrationtestplugin/service/healthcheck/HttpHealthCheck.groovy
+++ b/buildSrc/msintplugin/src/main/groovy/de/db/vz/integrationtestplugin/service/healthcheck/HttpHealthCheck.groovy
@@ -30,7 +30,7 @@ class HttpHealthCheck extends HealthCheck {
 
         def builder = new ProcessBuilder('docker', 'run', '--rm', "--net=$network",
                 IntegrationTestPlugin.integrationTestExtension.curlImage,
-                '-sw','\'%{http_code}\n\'', '-o', '/dev/null',
+                '-sw', '%{http_code}\n', '-o', '/dev/null',
                 "http://${service}${healthEndpoint}")
         logger.debug("health check docker command: ${builder.command()}")
         Process process = builder.start()


### PR DESCRIPTION
Because the carriage return was missing, it looks like the some local shell settings was producing a race condition. If I fetch the correct docker command per 
```
./gradlew integrationtestup -d | grep curl -C 4
```
and run it, for e.g.
```
docker run --rm --net=agtcbfqfi_default appropriate/curl -s -o /dev/null -w %{http_code}  http://parcel-gateway:8080/health
```
the expected status code `200` is just blinking up.. I don't know what is responsible for this behaviour, but this pull request is fixing it. 